### PR TITLE
(chorko) FIX: vinyl record and event card hover

### DIFF
--- a/components/eventCard.tsx
+++ b/components/eventCard.tsx
@@ -13,72 +13,104 @@ interface EventCardProps {
   description: string;
   registrationLink: string;
   category: string;
+  isVinylHovered: boolean;
 }
 
-export default function EventCard({ title, date, location, image, description, category }: EventCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
+export default function EventCard({ 
+  title, 
+  date, 
+  location, 
+  image, 
+  description, 
+  category,
+  isVinylHovered 
+}: EventCardProps) {
+  const [isHovered, setIsHovered] = useState(false);
   const [showPopup, setShowPopup] = useState(false);
+
+  // Dynamic z-index calculation based on both states
+  const getZIndex = () => {
+    if (isVinylHovered) {
+      // When vinyl is hovered, keep cards well below vinyl (z-index 20)
+      return 1;
+    } else {
+      // When vinyl is not hovered, cards can be above
+      return isHovered ? 7 : 6;
+    }
+  };
 
   return (
     <>
-    <div
-      className="relative w-full h-96 overflow-hidden rounded-lg shadow-lg"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
-      <Image
-        src={image || "/placeholder.svg"}
-        alt={title}
-        layout="fill"
-        objectFit="cover"
-        className="transition-transform duration-300 ease-in-out transform hover:scale-110"
-      />
-      <motion.div
-        className="absolute inset-0 bg-black bg-opacity-70 p-4 flex flex-col justify-between"
-        initial={{ x: "-100%" }}
-        animate={{ x: isHovered ? 0 : "-100%" }}
-        transition={{ duration: 0.3 }}
+      <div
+        className="relative w-full h-96 overflow-hidden rounded-lg shadow-lg cursor-pointer"
+        style={{ 
+          zIndex: getZIndex(),
+          transition: 'z-index 0.3s'
+        }}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={(e) => {
+          const relatedTarget = e.relatedTarget as HTMLElement;
+          if (!relatedTarget?.closest('.hover-content')) {
+            setIsHovered(false);
+          }
+        }}
       >
-        <div>
+        <Image
+          src={image || "/placeholder.svg"}
+          alt={title}
+          layout="fill"
+          objectFit="cover"
+          className="transition-transform duration-300 ease-in-out transform hover:scale-110"
+        />
+        <motion.div
+          className="absolute inset-0 bg-black bg-opacity-70 p-4 flex flex-col justify-between hover-content"
+          style={{ zIndex: isVinylHovered ? 1 : 7 }} // Keep hover content at same level as card when vinyl hovered
+          initial={{ x: "-100%" }}
+          animate={{ x: isHovered ? 0 : "-100%" }}
+          transition={{ duration: 0.3 }}
+        >
+          <div>
+            <h3 className="text-2xl text-white relative pb-4 font-lexend">{title}</h3>
+            <p className="text-white mb-2">{date}</p>
+            <p className="text-white mb-2">{location}</p>
+            <p className="text-white">{description}</p>
+          </div>
+          <button 
+            onClick={() => setShowPopup(true)}
+            className="button bg-white text-black py-2 px-4 rounded self-start overflow-hidden hover-content"
+          >
+            <span className="inline-block">
+              {"VIEW MORE".split("").map((letter, index) => (
+                <motion.span
+                  key={index}
+                  className="letter inline-block"
+                  initial={{ rotateX: 0, opacity: 1 }}
+                  animate={{ rotateX: isHovered ? 360 : 0, opacity: 1 }}
+                  transition={{ duration: 1.0, delay: index * 0.1 }}
+                >
+                  {letter}
+                </motion.span>
+              ))}
+            </span>
+          </button>
+        </motion.div>
+        <div className="absolute top-0 left-0 p-4" style={{ zIndex: isVinylHovered ? 1 : 10 }}>
           <h3 className="text-2xl text-white relative pb-4 font-lexend">{title}</h3>
-          <p className="text-white mb-2">{date}</p>
-          <p className="text-white mb-2">{location}</p>
-          <p className="text-white">{description}</p>
         </div>
-        <button onClick={() => setShowPopup(true)}
-className="button bg-white text-black py-2 px-4 rounded self-start overflow-hidden">
-          <span className="inline-block">
-            {"VIEW MORE".split("").map((letter, index) => (
-              <motion.span
-                key={index}
-                className="letter inline-block"
-                initial={{ rotateX: 0, opacity: 1 }}
-                animate={{ rotateX: isHovered ? 360 : 0, opacity: 1 }}
-                transition={{ duration: 1.0, delay: index * 0.1 }}
-              >
-                {letter}
-              </motion.span>
-            ))}
-          </span>
-        </button>
-      </motion.div>
-      <div className="absolute top-0 left-0 p-4 z-10">
-        <h3 className="text-2xl text-white relative pb-4 font-lexend">{title}</h3>
       </div>
-    </div>
 
-{showPopup && (
-  <EventPopup
-    id = {title}
-    title={title}
-    date={date}
-    location={location}
-    description={description}
-    category={category}
-    onClose={() => setShowPopup(false)}
-  />
-)}
-</>
+      {showPopup && (
+        <EventPopup
+          id={title}
+          title={title}
+          date={date}
+          location={location}
+          description={description}
+          category={category}
+          onClose={() => setShowPopup(false)}
+        />
+      )}
+    </>
   )
 }
 

--- a/components/event_selector.module.css
+++ b/components/event_selector.module.css
@@ -25,7 +25,7 @@
   opacity: 0;
   transition: all 0.6s ease;
   pointer-events: none;
-  z-index: 10; /* Above background (1), below vinyl (20) and waves (16) */
+  z-index: 2;
 }
 
 /* Show blur when vinyl is hovered */
@@ -35,8 +35,23 @@
 
 /* Event grid */
 .eventGrid {
+  margin-left: 25%;
+  padding: 2rem;
+  padding-top: 6rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 2rem;
   position: relative;
   z-index: 5;
+  transition: all 0.3s ease;
+  isolation: isolate;
+}
+
+/* Add new class for when vinyl is hovered */
+.eventGrid.behindVinyl {
+  z-index: 1;
+  opacity: 0.8;
+  transition: all 0.3s ease;
 }
 
 /* Vinyl and categories */
@@ -55,7 +70,7 @@
 
 /* Modal */
 .modal {
-  z-index: 30;
+  z-index: 50;
 }
 
 /* Sound wave */
@@ -69,7 +84,7 @@
   gap: 2px;
   height: 175px;
   width: 100vw;
-  z-index: 16;
+  z-index: 3;
   opacity: 0;
   transition: opacity 0.5s ease;
   padding: 0;
@@ -247,7 +262,7 @@
   left: 38%;
   top: 50%;
   transform: translateY(-50%);
-  z-index: 21;
+  z-index: 4;
   opacity: 0;
   visibility: hidden;
   transition: opacity 0.3s ease, visibility 0.3s ease;
@@ -296,19 +311,6 @@
   text-shadow: 0 0 10px rgba(255,69,0,0.5);
 }
 
-/* Update Event Grid Styles */
-.eventGrid {
-  margin-left: 25%;
-  padding: 2rem;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 2rem;
-  position: relative;
-  z-index: 1;
-  transition: opacity 0.3s ease;
-  isolation: isolate;
-}
-
 /* Optional: Slightly dim the events when vinyl is expanded */
 .vinyl.expanded ~ .eventGrid {
   opacity: 0.8;
@@ -325,7 +327,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 4;
+  z-index: 50;
 }
 
 .modalContent {
@@ -457,7 +459,7 @@
   left: 5%; /* Adjust to fit next to the triangle */
   top: 50%;
   transform: translateY(-50%);
-  z-index: 21;
+  z-index: 4;
   opacity: 1;
   visibility: visible;
   transition: opacity 0.3s ease, visibility 0.3s ease;
@@ -569,7 +571,7 @@
   /* Adjust event grid for mobile */
   .eventGrid {
     margin-left: 0;
-    margin-top: 200px;
+    margin-top: 240px; /* Increase top margin for mobile */
     padding: 1rem;
     grid-template-columns: 1fr;
   }

--- a/components/event_selector.tsx
+++ b/components/event_selector.tsx
@@ -30,6 +30,7 @@ const Eventsdisc: React.FC<EventsdiscProps> = ({ events }) => {
   const soundBarRefs = useRef<(HTMLDivElement | null)[]>([])
   const [isMobile, setIsMobile] = useState(false)
   const [isClient, setIsClient] = useState(false)
+  const [isVinylHovered, setIsVinylHovered] = useState(false)
 
   const categories = useMemo(() => ['All', 'Technical', 'Non-Technical', 'Workshops'], [])
 
@@ -139,12 +140,14 @@ const Eventsdisc: React.FC<EventsdiscProps> = ({ events }) => {
         onMouseEnter={() => {
           if (!isMobile) {
             setIsVinylExpanded(true)
+            setIsVinylHovered(true)
             resetWaveAnimation()
           }
         }}
         onMouseLeave={() => {
           if (!isMobile) {
             setIsVinylExpanded(false)
+            setIsVinylHovered(false)
           }
         }}
         onClick={() => {
@@ -205,10 +208,11 @@ const Eventsdisc: React.FC<EventsdiscProps> = ({ events }) => {
         {soundBars}
       </div>
 
-      <div className={styles.eventGrid}>
+      <div className={`${styles.eventGrid} ${isVinylHovered ? styles.behindVinyl : ''}`}>
         {filteredEvents.map(event => (
           <EventCard
             key={event.id}
+            isVinylHovered={isVinylHovered}
             title={event.title}
             date={event.date}
             location={event.venue || 'TBA'}
@@ -216,7 +220,6 @@ const Eventsdisc: React.FC<EventsdiscProps> = ({ events }) => {
             description={event.description}
             registrationLink={event.registerLink || 'TBA' }
             category={event.category}
-            
           />
         ))}
       </div>


### PR DESCRIPTION
fixed the z-index issue by dynmically changing the z-index of the event card upon hovering over the static vinyl records

The z-index that has been updated

Z-INDEX HIERARCHY:

50 - Highest Level
- EventPopup/Modal
- Modal Content

20 - Vinyl Level
- Vinyl Wrapper
- Vinyl Controls

15 - Overlay Level
- Blur Overlay

10 - Event Grid Base Level
- Event Grid (when vinyl not hovered)

7 - Card Active Level (when vinyl not hovered)
- Card Hover Content
- Card when Hovered

6 - Card Base Level (when vinyl not hovered)
- Card Default State

5 - Grid Level
- Event Grid Base

4 - Vinyl Components
- Static Categories
- Categories Container

3 - Animation Level
- Sound Wave
- Vinyl Base

2 - Background Level
- Blur Overlay Base State

1 - Behind Vinyl Level (when vinyl hovered)
- Event Grid (when vinyl hovered)
- Cards (when vinyl hovered)
- Card Hover Content (when vinyl hovered)

0 - Base Level
- Container Background
![image](https://github.com/user-attachments/assets/d7bd5433-7202-433d-b712-d7bed64cc63a)
